### PR TITLE
Add web service dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,6 @@
-playwright 
+playwright        # Browser automation library
+
+fastapi          # Web framework for building APIs
+uvicorn          # ASGI server to run FastAPI apps
+httpx            # Async HTTP client
+selectolax       # Fast HTML parser based on lexbor


### PR DESCRIPTION
## Summary
- document dependencies for FastAPI app

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68424e8a245c83259760e5a5676984f9